### PR TITLE
Change dependency angular-moment version to beta

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,3 +29,6 @@ Changelog
 * Add nativeOnMobile options in order to delegate to system timepicker on mobile devices
 
 * Correct update of view on mutation of moment date
+
+1.1.1
+* Change dependency angular-moment version to beta

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-clockpicker",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "authors": [
     "Linagora folks"
     ],

--- a/bower.json
+++ b/bower.json
@@ -25,7 +25,7 @@
     "dependencies": {
       "lng-clockpicker": "~0.0.8",
       "angular": "^1.3.0",
-      "angular-moment": "~1.0.0",
+      "angular-moment": "1.0.0-beta.3",
       "ng-device-detector": "~1.1.7"
     },
     "devDependencies": {


### PR DESCRIPTION
hi, my bower on jenkins machine cry for **angular-moment** dependency because it's in beta ("_no tag found that was able to satisfy ~1.0.0_"). would you mind to merge that tiny change ? 
best regards
